### PR TITLE
Handle processor and gateway rejection error responses

### DIFF
--- a/public_html/checkout.php
+++ b/public_html/checkout.php
@@ -12,6 +12,10 @@ $result = Braintree\Transaction::sale([
 if ($result->success){
     $transaction = $result->transaction;
     header("Location: transaction.php?id=" . $transaction->id);
+} elseif (!is_null($result->transaction)){
+    $transaction = $result->transaction;
+    $_SESSION["errors"] = "Transaction status - " . $result->transaction->status;
+    header("Location: transaction.php?id=" . $transaction->id);
 } else {
     $errorString = "";
 
@@ -21,5 +25,4 @@ if ($result->success){
 
     $_SESSION["errors"] = $errorString;
     header("Location: index.php");
-
 }

--- a/public_html/transaction.php
+++ b/public_html/transaction.php
@@ -1,5 +1,10 @@
 <?php
     require_once("../includes/braintree_init.php");
+
+    if(isset($_SESSION["errors"])) {
+        echo($_SESSION["errors"]);
+        unset($_SESSION["errors"]);
+    }
     if (isset($_GET["id"])) {
       $transaction = Braintree\Transaction::find($_GET["id"]);
     }

--- a/tests/integration/CheckoutPageTest.php
+++ b/tests/integration/CheckoutPageTest.php
@@ -78,4 +78,30 @@ class CheckoutPageTest extends PHPUnit_Framework_TestCase
         $this->assertRegExp('/\/index.php/', $redirectUrl);
         $this->assertRegExp('/Cannot use a paymentMethodNonce more than once./', $output);
     }
+
+    function test_displaysStatusOnProcessorAndGatewayErrors()
+    {
+        $fields = array(
+            'amount' => 2000,
+            'payment_method_nonce' => "fake-valid-nonce"
+        );
+
+        $fields_string = "";
+        foreach($fields as $key=>$value) { $fields_string .= $key.'='.$value.'&'; }
+        rtrim($fields_string, '&');
+
+        $curl = curl_init();
+        curl_setopt($curl, CURLOPT_URL, "localhost:3000/checkout.php");
+        curl_setopt($curl, CURLOPT_POSTFIELDS, $fields_string);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, 1);
+        curl_setopt($curl, CURLOPT_COOKIEFILE, "");
+        $output = curl_exec($curl);
+
+        $redirectUrl = curl_getinfo($curl, CURLINFO_EFFECTIVE_URL);
+        curl_close($curl);
+
+        $this->assertRegExp('/\/transaction.php\?id=/', $redirectUrl);
+        $this->assertRegExp('/Transaction status - processor_declined/', $output);
+    }
 }


### PR DESCRIPTION
In cases where a transaction is declined by the processor or rejected by the payments gateway, a transaction is created, but the error is depicted in the transaction status. In these cases, we continue to redirect the user to the transaction page, but highlight the transaction status to indicate that the transaction was not a success.
