### PR TITLE
Small changes to make the example repos idiomatic

### DIFF
--- a/public_html/checkout.php
+++ b/public_html/checkout.php
@@ -20,7 +20,7 @@ if ($result->success){
     $errorString = "";
 
     foreach($result->errors->deepAll() AS $error) {
-        $errorString .= $error->code . "-" . $error->message . "\n";
+        $errorString .= 'Error: ' . $error->code . ": " . $error->message . "\n";
     }
 
     $_SESSION["errors"] = $errorString;

--- a/tests/integration/CheckoutPageTest.php
+++ b/tests/integration/CheckoutPageTest.php
@@ -76,7 +76,7 @@ class CheckoutPageTest extends PHPUnit_Framework_TestCase
         curl_close($curl);
 
         $this->assertRegExp('/\/index.php/', $redirectUrl);
-        $this->assertRegExp('/Cannot use a paymentMethodNonce more than once./', $output);
+        $this->assertRegExp('/Error: 91564: Cannot use a paymentMethodNonce more than once./', $output);
     }
 
     function test_displaysStatusOnProcessorAndGatewayErrors()


### PR DESCRIPTION
Formatting the errors to be idiomatic with the rails example repo
