### PR TITLE
Add Procfile and default to system env settings when dot-env file missing

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: php -S 0.0.0.0:$PORT -t public_html

--- a/includes/braintree_init.php
+++ b/includes/braintree_init.php
@@ -2,8 +2,10 @@
 session_start();
 require_once("../vendor/autoload.php");
 
-$dotenv = new Dotenv\Dotenv(__DIR__ . "/../");
-$dotenv->load();
+if(file_exists(__DIR__ . "/../.env")) {
+    $dotenv = new Dotenv\Dotenv(__DIR__ . "/../");
+    $dotenv->load();
+}
 
 Braintree\Configuration::environment(getenv('BT_ENVIRONMENT'));
 Braintree\Configuration::merchantId(getenv('BT_MERCHANT_ID'));


### PR DESCRIPTION
We want to integrate a "Deploy to Heroku" button to enable people who do not have development experience to easily launch our example integration and explore the running application.

This PR updates our integration to use environment variables to configure the app and adds a Procfile to specify the webserver to serve the app. Following this PR we will add the code to include a "Deploy to Heroku" button on the README.md
