### PR TITLE
Use an instantiated gateway object instead of static method calls

### DIFF
--- a/includes/braintree_init.php
+++ b/includes/braintree_init.php
@@ -7,7 +7,9 @@ if(file_exists(__DIR__ . "/../.env")) {
     $dotenv->load();
 }
 
-Braintree\Configuration::environment(getenv('BT_ENVIRONMENT'));
-Braintree\Configuration::merchantId(getenv('BT_MERCHANT_ID'));
-Braintree\Configuration::publicKey(getenv('BT_PUBLIC_KEY'));
-Braintree\Configuration::privateKey(getenv('BT_PRIVATE_KEY'));
+$gateway = new Braintree\Gateway([
+    'environment' => getenv('BT_ENVIRONMENT'),
+    'merchantId' => getenv('BT_MERCHANT_ID'),
+    'publicKey' => getenv('BT_PUBLIC_KEY'),
+    'privateKey' => getenv('BT_PRIVATE_KEY')
+]);

--- a/public_html/checkout.php
+++ b/public_html/checkout.php
@@ -4,7 +4,7 @@ require_once("../includes/braintree_init.php");
 $amount = $_POST["amount"];
 $nonce = $_POST["payment_method_nonce"];
 
-$result = Braintree\Transaction::sale([
+$result = $gateway->transaction()->sale([
     'amount' => $amount,
     'paymentMethodNonce' => $nonce,
     'options' => [

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -39,7 +39,7 @@
     <script src="https://js.braintreegateway.com/web/dropin/1.9.2/js/dropin.min.js"></script>
     <script>
         var form = document.querySelector('#payment-form');
-        var client_token = "<?php echo(Braintree\ClientToken::generate()); ?>";
+        var client_token = "<?php echo($gateway->ClientToken()->generate()); ?>";
 
         braintree.dropin.create({
           authorization: client_token,

--- a/public_html/transaction.php
+++ b/public_html/transaction.php
@@ -6,7 +6,7 @@
     require_once("../includes/braintree_init.php");
     require_once("../includes/header.php");
     if (isset($_GET["id"])) {
-        $transaction = Braintree\Transaction::find($_GET["id"]);
+        $transaction = $gateway->transaction()->find($_GET["id"]);
 
         $transactionSuccessStatuses = [
             Braintree\Transaction::AUTHORIZED,

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -7,7 +7,9 @@ if(file_exists(__DIR__ . "/../.env")) {
     $dotenv->load();
 }
 
-Braintree\Configuration::environment(getenv('BT_ENVIRONMENT'));
-Braintree\Configuration::merchantId(getenv('BT_MERCHANT_ID'));
-Braintree\Configuration::publicKey(getenv('BT_PUBLIC_KEY'));
-Braintree\Configuration::privateKey(getenv('BT_PRIVATE_KEY'));
+$gateway = new Braintree\Gateway([
+    'environment' => getenv('BT_ENVIRONMENT'),
+    'merchantId' => getenv('BT_MERCHANT_ID'),
+    'publicKey' => getenv('BT_PUBLIC_KEY'),
+    'privateKey' => getenv('BT_PRIVATE_KEY')
+]);

--- a/tests/integration/TransactionPageTest.php
+++ b/tests/integration/TransactionPageTest.php
@@ -5,7 +5,8 @@ class TransactionPageTest extends PHPUnit_Framework_TestCase
 {
     function test_showsTransactionInformation()
     {
-        $result = Braintree\Transaction::sale([
+        global $gateway;
+        $result = $gateway->transaction()->sale([
             'amount' => 10,
             'paymentMethodNonce' => 'fake-valid-nonce'
         ]);


### PR DESCRIPTION
Instantiating a gateway with merchant credentials supports a wider
range of authentication methods for all types of Braintree merchants.