### PR TITLE
Fixed install to not root directory(e.g copy zip archive)

### DIFF
--- a/includes/braintree_init.php
+++ b/includes/braintree_init.php
@@ -13,3 +13,5 @@ $gateway = new Braintree\Gateway([
     'publicKey' => getenv('BT_PUBLIC_KEY'),
     'privateKey' => getenv('BT_PRIVATE_KEY')
 ]);
+$baseUrl = stripslashes(dirname($_SERVER['SCRIPT_NAME']));
+$baseUrl = $baseUrl == '/' ? $baseUrl : $baseUrl . '/';

--- a/public_html/checkout.php
+++ b/public_html/checkout.php
@@ -14,7 +14,7 @@ $result = $gateway->transaction()->sale([
 
 if ($result->success || !is_null($result->transaction)) {
     $transaction = $result->transaction;
-    header("Location: transaction.php?id=" . $transaction->id);
+    header("Location: " . $baseUrl . "transaction.php?id=" . $transaction->id);
 } else {
     $errorString = "";
 
@@ -23,5 +23,5 @@ if ($result->success || !is_null($result->transaction)) {
     }
 
     $_SESSION["errors"] = $errorString;
-    header("Location: index.php");
+    header("Location: " . $baseUrl . "index.php");
 }

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -16,7 +16,7 @@
                 </p>
             </header>
 
-            <form method="post" id="payment-form" action="/checkout.php">
+            <form method="post" id="payment-form" action="<?php echo $baseUrl;?>checkout.php">
                 <section>
                     <label for="amount">
                         <span class="input-label">Amount</span>

--- a/public_html/transaction.php
+++ b/public_html/transaction.php
@@ -1,9 +1,9 @@
+<?php  require_once("../includes/braintree_init.php"); ?>
 <html>
 <?php require_once("../includes/head.php"); ?>
 <body>
 
 <?php
-    require_once("../includes/braintree_init.php");
     require_once("../includes/header.php");
     if (isset($_GET["id"])) {
         $transaction = $gateway->transaction()->find($_GET["id"]);


### PR DESCRIPTION
1. Fixed: If user copy example to not root directory (e.g http://localhost:3000/braintree_php_example-master), we have not correct link for form in index.php, expected action = "/braintree_php_example-master/public_html/checkout.php" actual action = "/checkout.php"
2. Fixed: In page  http://localhost:3000/transaction.php?id=XXXXXX showing warning "Warning: :  session_start(): Cannot send session cache limiter - headers already sent ..." because braintree_init.php included after send html.