### PR TITLE
Throw error if required env variables do not exist

### DIFF
--- a/includes/braintree_init.php
+++ b/includes/braintree_init.php
@@ -5,8 +5,10 @@ require_once("../vendor/autoload.php");
 if(file_exists(__DIR__ . "/../.env")) {
     $dotenv = new Dotenv\Dotenv(__DIR__ . "/../");
     $dotenv->load();
-} else {
-    throw new Exception('Cannot find .env file. See https://github.com/braintree/braintree_php_example#setup-instructions for instructions');
+}
+
+if (!getenv('BT_ENVIRONMENT') || !getenv('BT_MERCHANT_ID') || !getenv('BT_PUBLIC_KEY') || !getenv('BT_PRIVATE_KEY')) {
+    throw new Exception('Cannot find necessary environmental variables. See https://github.com/braintree/braintree_php_example#setup-instructions for instructions');
 }
 
 $gateway = new Braintree\Gateway([

--- a/includes/braintree_init.php
+++ b/includes/braintree_init.php
@@ -5,6 +5,8 @@ require_once("../vendor/autoload.php");
 if(file_exists(__DIR__ . "/../.env")) {
     $dotenv = new Dotenv\Dotenv(__DIR__ . "/../");
     $dotenv->load();
+} else {
+    throw new Exception('Cannot find .env file. See https://github.com/braintree/braintree_php_example#setup-instructions for instructions');
 }
 
 $gateway = new Braintree\Gateway([


### PR DESCRIPTION
A constant source of issues on these repos is forgetting to set the `.env` file. This throws an error and points to the instructions.