### PR TITLE
Update Dotenv initialization for compatibility with phpdotenv

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "require" : {
-    "braintree/braintree_php" : "5.0.0",
+    "braintree/braintree_php" : "6.11.2",
     "php": ">=8.0.0",
-    "vlucas/phpdotenv": ">=2.1.0"
+    "vlucas/phpdotenv": "~5.5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",

--- a/includes/braintree_init.php
+++ b/includes/braintree_init.php
@@ -3,7 +3,7 @@ session_start();
 require_once('../vendor/autoload.php');
 
 if(file_exists(__DIR__ . '/../.env')) {
-    $dotenv = new Dotenv\Dotenv(__DIR__ . '/../');
+    $dotenv = Dotenv\Dotenv::createUnsafeImmutable(__DIR__ . '/../');
     $dotenv->load();
 }
 

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -3,7 +3,7 @@ session_start();
 require_once("vendor/autoload.php");
 
 if(file_exists(__DIR__ . "/../.env")) {
-    $dotenv = new Dotenv\Dotenv(__DIR__ . "/../");
+    $dotenv = Dotenv\Dotenv::createUnsafeImmutable(__DIR__ . '/../');
     $dotenv->load();
 }
 


### PR DESCRIPTION
Dotenv initialization was written for vlucas/phpdotenv version < 3.
composer installs newer version of vlucas/phpdotenv is not backwards compatible with existing Dotenv initialization.

For internal tracking, issue 2561.