### PR TITLE
chore: add drop-in deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 [![Build Status](https://github.com/braintree/braintree_php_example/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/braintree/braintree_php_example/actions/workflows/ci.yml)
 
+> [!WARNING]
+> Starting September 1, 2026 the Drop-in SDK will move to a [deprecated status](https://developer.paypal.com/braintree/docs/guides/client-sdk/deprecation-policy/javascript/v3/#status-categories) and we will no longer make any updates to this SDK. Processing will be supported for 1 year after the deprecation date, but you should upgrade immediately to avoid any disruption.
+>
+> Starting September 1, 2027 the Drop-in SDK will move to an [unsupported status](https://developer.paypal.com/braintree/docs/guides/client-sdk/deprecation-policy/javascript/v3/#status-categories) and will no longer be supported by Braintree developers or Braintree Support. Processing for unsupported SDKs can be suspended at any time.
+>
+> Please migrate to [Hosted Fields](https://developer.paypal.com/braintree/docs/start/tutorial-hosted-fields-node/) to continue processing and receiving updates.
+
 An example Braintree integration for PHP.
 
 ## Setup Instructions


### PR DESCRIPTION
drop-in is being deprecated. we want to encourage merchants to move to hosted fields instead.

i was not able to get this running, or else i would have liked to try to move it over myself. but we have it on the roadmap to do that in the near future